### PR TITLE
Split ca_cert_data into certs and create binding for each

### DIFF
--- a/config/ca_cert.yaml
+++ b/config/ca_cert.yaml
@@ -4,17 +4,40 @@
 #@ load("@ytt:data", "data")
 #@ load("@ytt:overlay", "overlay")
 
+#@ def split_certs():
+#@   ca_certs_lines=data.values.ca_cert_data.splitlines()
+#@   ca_certs = []
+#@   i1=0
+#@   i2=0
+#@   for ca_cert_line in ca_certs_lines:
+#@     if ca_cert_line == "-----END CERTIFICATE-----" :
+#@       ca_certs.append("\n".join(ca_certs_lines[i1:i2+1]))
+#@       i1=i2+1
+#@     end
+#@     i2+=1
+#@   end
+#@   return ca_certs
+#@ end
+
+#@ ca_certs=split_certs()
+
 #@ if data.values.ca_cert_data != "":
+#@ i = 0
+#@ for ca_cert in ca_certs:
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: ca-certificates-binding
+  name: #@ "ca-certificates-binding-" + str(i)
   namespace: kpack
 type: servicebinding.io/ca-certificates
 stringData:
   type: ca-certificates
-  certificates: #@ data.values.ca_cert_data
+  certificate: #@ ca_cert
+#@ i += 1
+#@ end
+
+
 
 #@overlay/match by=overlay.subset({"metadata":{"name":"kpack-controller"}, "kind": "Deployment"})
 ---
@@ -31,13 +54,21 @@ spec:
               value: "/bindings"
           #@overlay/match missing_ok=True
           volumeMounts:
+            #@ i = 0
+            #@ for ca_cert in ca_certs:
             #@overlay/append
-            - mountPath: /bindings/ca-certificates
-              name: ca-certificates
+            - mountPath: #@ "/bindings/ca-certificate-" + str(i)
+              name: #@ "ca-certificate-" + str(i)
+            #@ i += 1
+            #@ end
       #@overlay/match missing_ok=True
       volumes:
+        #@ i = 0
+        #@ for ca_cert in ca_certs:
         #@overlay/append
-        - name: ca-certificates
+        - name: #@ "ca-certificate-" + str(i)
           secret:
-            secretName: ca-certificates-binding
+            secretName: #@ "ca-certificates-binding-" + str(i)
+        #@ i += 1
+        #@ end
 #@ end

--- a/config/ca_cert.yaml
+++ b/config/ca_cert.yaml
@@ -3,41 +3,46 @@
 
 #@ load("@ytt:data", "data")
 #@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:assert", "assert")
 
 #@ def split_certs():
 #@   ca_certs_lines=data.values.ca_cert_data.splitlines()
 #@   ca_certs = []
 #@   i1=0
 #@   i2=0
+#@   found_cert = True
 #@   for ca_cert_line in ca_certs_lines:
+#@     found_cert = False
 #@     if ca_cert_line == "-----END CERTIFICATE-----" :
 #@       ca_certs.append("\n".join(ca_certs_lines[i1:i2+1]))
 #@       i1=i2+1
+#@       found_cert = True
 #@     end
 #@     i2+=1
 #@   end
+#@   found_cert or assert.fail("misconfigured ca_cert_data")
 #@   return ca_certs
 #@ end
 
-#@ ca_certs=split_certs()
-
 #@ if data.values.ca_cert_data != "":
-#@ i = 0
-#@ for ca_cert in ca_certs:
+#@ ca_certs=split_certs()
+#@yaml/text-templated-strings
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: #@ "ca-certificates-binding-" + str(i)
+  name: ca-certificates-binding
   namespace: kpack
+  annotations:
+    kapp.k14s.io/versioned: ""
 type: servicebinding.io/ca-certificates
 stringData:
   type: ca-certificates
-  certificate: #@ ca_cert
-#@ i += 1
-#@ end
-
-
+  #@ i = 0
+  #@ for ca_cert in ca_certs:
+  certificate_(@= str(i) @): #@ ca_cert
+  #@ i += 1
+  #@ end
 
 #@overlay/match by=overlay.subset({"metadata":{"name":"kpack-controller"}, "kind": "Deployment"})
 ---
@@ -54,21 +59,13 @@ spec:
               value: "/bindings"
           #@overlay/match missing_ok=True
           volumeMounts:
-            #@ i = 0
-            #@ for ca_cert in ca_certs:
             #@overlay/append
-            - mountPath: #@ "/bindings/ca-certificate-" + str(i)
-              name: #@ "ca-certificate-" + str(i)
-            #@ i += 1
-            #@ end
+            - mountPath: /bindings/ca-certificates
+              name: ca-certificates
       #@overlay/match missing_ok=True
       volumes:
-        #@ i = 0
-        #@ for ca_cert in ca_certs:
         #@overlay/append
-        - name: #@ "ca-certificate-" + str(i)
+        - name: ca-certificates
           secret:
-            secretName: #@ "ca-certificates-binding-" + str(i)
-        #@ i += 1
-        #@ end
+            secretName: ca-certificates-binding
 #@ end


### PR DESCRIPTION
- This fixes issues with concatenated certs with ca certs buildpacks

result is multiple secrets in the kpack namespace named and volume + volume mounts for each:
- `ca-certificates-binding-0`
- `ca-certificates-binding-1`

I cannot find a good way to refactor the ytt code